### PR TITLE
Default App::instance to get 'LimeApp'

### DIFF
--- a/src/Lime/App.php
+++ b/src/Lime/App.php
@@ -261,7 +261,7 @@ class App implements \ArrayAccess {
     * @param  String $name Lime app name
     * @return Object       Lime app object
     */
-    public static function instance($name) {
+    public static function instance($name = 'LimeApp') {
         return self::$apps[$name];
     }
 


### PR DESCRIPTION
For single-Lime scripts, the name of the only instance we make isn't immediately obvious but it stands to reason that calling App::instance() should return it without complaint.